### PR TITLE
Rewrote spatial extraction functions to work on both pecan2 and SCC

### DIFF
--- a/project_functions/arid_extract.r
+++ b/project_functions/arid_extract.r
@@ -12,9 +12,15 @@
 #' @export
 #'
 #' @examples
-arid_extract <- function(latitude, longitude, path = '/fs/data3/caverill/Global_Aridity/aridity/w001001.adf'){
-  #path to Global Aridity Index raster.
-  path <- '/fs/data3/caverill/Global_Aridity/aridity/w001001.adf'
+arid_extract <- function(latitude, longitude, folder = '/project/talbot-lab-data/spatial_raster_data/Global_Aridity/'){
+  #get hostname
+  host <- system('hostname', intern=T)
+  
+  #Change directory if you are on pecan2
+  if(host == 'pecan2'){folder <- '/fs/data3/caverill/Global_Aridity/'}
+  
+  #drop path.
+  path <- paste0(folder,'aridity/w001001.adf')
   
   #load raster
   arid <- raster::raster(path)

--- a/project_functions/extract_ndep.r
+++ b/project_functions/extract_ndep.r
@@ -12,7 +12,14 @@
 #'
 #' @examples
 
-extract_ndep <- function(longitude,latitude,folder='/fs/data3/caverill/CASTNET_Ndep/'){
+extract_ndep <- function(longitude,latitude,folder='/project/talbot-lab-data/spatial_raster_data/CASTNET_Ndep/'){
+  
+  #get hostname
+  host <- system('hostname', intern=T)
+  
+  #if you are on pecan2 go here instead.
+  if(host == 'pecan2'){folder <- '/fs/data3/caverill/CASTNET_Ndep/'}
+  
   #load dry deposition rasters
   dry.list <- list()
   for(i in 0:15){

--- a/project_functions/worldclim2_grab.r
+++ b/project_functions/worldclim2_grab.r
@@ -25,17 +25,24 @@ worldclim2_grab <- function(latitude,longitude,elev = 500, n.sim = 1000){
   
   #make points an object
   points <- cbind(longitude, latitude)
+  
+  #get hostname
+  host <- system('hostname', intern=T)
+  
+  #Where is WorldClim2 directory? Default SCC.
+  main.dir <-'/project/talbot-lab-data/spatial_raster_data/'
+  if(host == 'pecan2'){main.dir <- '/fs/data3/caverill/'}
  
   #load mean annual temperature and precipitation rasters from worldclim2
-  prec    <- raster::raster('/fs/data3/caverill/WorldClim2/wc2.0_bio_30s_12.tif')
-  temp    <- raster::raster('/fs/data3/caverill/WorldClim2/wc2.0_bio_30s_01.tif')
-  temp_CV <- raster::raster('/fs/data3/caverill/WorldClim2/wc2.0_bio_30s_04.tif')
-  prec_CV <- raster::raster('/fs/data3/caverill/WorldClim2/wc2.0_bio_30s_15.tif')
-  mdr     <- raster::raster('/fs/data3/caverill/WorldClim2/wc2.0_bio_30s_02.tif')
-  
+  prec    <- raster::raster(paste0(main.dir,'WorldClim2/wc2.0_bio_30s_12.tif'))
+  temp    <- raster::raster(paste0(main.dir,'WorldClim2/wc2.0_bio_30s_01.tif'))
+  temp_CV <- raster::raster(paste0(main.dir,'WorldClim2/wc2.0_bio_30s_04.tif'))
+  prec_CV <- raster::raster(paste0(main.dir,'WorldClim2/wc2.0_bio_30s_15.tif'))
+  mdr     <- raster::raster(paste0(main.dir,'WorldClim2/wc2.0_bio_30s_02.tif'))
+
   #load runjags summaries of precipitation and temperature fitted vs. observed.
-  prec.jags <- readRDS('/fs/data3/caverill/NEFI_microbial_data/worldclim2_uncertainty/precipitation_JAGS_model.rds')
-  temp.jags <- readRDS('/fs/data3/caverill/NEFI_microbial_data/worldclim2_uncertainty/temperature_JAGS_model.rds')
+  prec.jags <- readRDS(paste0(main.dir,'worldclim2_uncertainty/precipitation_JAGS_model.rds'))
+  temp.jags <- readRDS(paste0(main.dir,'worldclim2_uncertainty/temperature_JAGS_model.rds'))
   
   #extract worldclim2 predicted climate data.
      prec.obs <- raster::extract(prec, points)


### PR DESCRIPTION
Rewrote spatial extraction functions to work on both pecan2 and the SCC. created a directory on the SCC with all spatial product data at /project/talbot-lab-data/spatial_raster_data/.